### PR TITLE
Configure external PostgreSQL connection

### DIFF
--- a/src/main/docker/app.yml
+++ b/src/main/docker/app.yml
@@ -7,8 +7,14 @@ services:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m
       - SPRING_PROFILES_ACTIVE=prod,api-docs
       - MANAGEMENT_PROMETHEUS_METRICS_EXPORT_ENABLED=true
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgresql:5432/citizenServices
-      - SPRING_LIQUIBASE_URL=jdbc:postgresql://postgresql:5432/citizenServices
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://173.212.199.139:5432/citizenServices
+      - SPRING_DATASOURCE_USERNAME=SyriaBazaar
+      - 'SPRING_DATASOURCE_PASSWORD=$yri@B@z@@r25'
+      - SPRING_LIQUIBASE_URL=jdbc:postgresql://173.212.199.139:5432/citizenServices
+      - SPRING_LIQUIBASE_USER=SyriaBazaar
+      - 'SPRING_LIQUIBASE_PASSWORD=$yri@B@z@@r25'
+      - SPRING_JPA_PROPERTIES_HIBERNATE_DEFAULT_SCHEMA=citizenServices
+      - SPRING_LIQUIBASE_DEFAULT_SCHEMA=citizenServices
     ports:
       - 127.0.0.1:8080:8080
     healthcheck:

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -32,15 +32,20 @@ spring:
       indent-output: true
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:postgresql://localhost:5432/citizenServices
-    username: citizenServices
-    password:
+    url: jdbc:postgresql://173.212.199.139:5432/citizenServices
+    username: SyriaBazaar
+    password: '$yri@B@z@@r25'
     hikari:
       poolName: Hikari
       auto-commit: false
+      schema: citizenServices
+  jpa:
+    properties:
+      hibernate.default_schema: citizenServices
   liquibase:
     # Remove 'faker' if you do not want the sample data to be loaded automatically
     contexts: dev, faker
+    default-schema: citizenServices
   mail:
     host: localhost
     port: 25

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -33,15 +33,20 @@ spring:
       enabled: false
   datasource:
     type: com.zaxxer.hikari.HikariDataSource
-    url: jdbc:postgresql://localhost:5432/citizenServices
-    username: citizenServices
-    password:
+    url: jdbc:postgresql://173.212.199.139:5432/citizenServices
+    username: SyriaBazaar
+    password: '$yri@B@z@@r25'
     hikari:
       poolName: Hikari
       auto-commit: false
+      schema: citizenServices
+  jpa:
+    properties:
+      hibernate.default_schema: citizenServices
   # Replace by 'prod, faker' to add the faker context and have sample data loaded in production
   liquibase:
     contexts: prod
+    default-schema: citizenServices
   mail:
     host: localhost
     port: 25


### PR DESCRIPTION
## Summary
- point dev and prod Spring profiles to the external PostgreSQL host with provided credentials
- align Hibernate and Liquibase with the citizenServices schema
- update the Docker app service environment to use the external database connection details

## Testing
- Not run (configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936ed9c55e883298b3b1bad16637d62)