### PR TITLE
Add encoding check for frontend TypeScript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config jest.conf.js",
     "jest:update": "npm run jest -- --updateSnapshot",
     "lint": "eslint .",
+    "lint:encoding": "node scripts/check-encoding.js",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "husky",
     "prettier:check": "prettier --check \"{,src/**/,webpack/,.blueprint/**/}*.{md,json,yml,js,cjs,mjs,ts,cts,mts,java,html,tsx,css,scss}\"",

--- a/scripts/check-encoding.js
+++ b/scripts/check-encoding.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const TARGET_DIR = path.join(ROOT, 'src', 'main', 'webapp', 'app');
+const EXTENSIONS = new Set(['.ts', '.tsx']);
+const FORBIDDEN = [
+  { char: '\uFFFD', description: 'replacement character (usually indicates decoding problems)' },
+  { char: '\uFEFF', description: 'byte order mark (BOM)' },
+];
+
+const offenders = [];
+
+const walk = dir => {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  entries.forEach(entry => {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(fullPath);
+    } else if (EXTENSIONS.has(path.extname(entry.name))) {
+      checkFile(fullPath);
+    }
+  });
+};
+
+const checkFile = filePath => {
+  const content = fs.readFileSync(filePath, 'utf8');
+  FORBIDDEN.forEach(({ char, description }) => {
+    const occurrences = content.split(char).length - 1;
+    if (occurrences > 0) {
+      offenders.push({ filePath, char, occurrences, description });
+    }
+  });
+};
+
+walk(TARGET_DIR);
+
+if (offenders.length > 0) {
+  console.error('Encoding issues detected:');
+  offenders.forEach(({ filePath, char, occurrences, description }) => {
+    console.error(`- ${filePath}: ${occurrences} occurrence(s) of ${char} (${description})`);
+  });
+  process.exit(1);
+}
+
+console.log('No encoding issues found in application TypeScript files.');


### PR DESCRIPTION
## Summary
- add a utility script to detect BOM or replacement characters in frontend TypeScript sources
- expose the checker via a new `lint:encoding` npm script to help catch encoding regressions early

## Testing
- npm run lint:encoding

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69371139d1e88329a482ff25fedc7604)