### PR TITLE
Add browser globals for webapp JavaScript linting

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,15 @@ export default tseslint.config(
   { ignores: ['target/classes/static/', 'target/'] },
   eslint.configs.recommended,
   {
+    files: ['src/main/webapp/**/*.{js,cjs,mjs}'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        MockApi: 'readonly',
+      },
+    },
+  },
+  {
     files: ['**/*.{js,cjs,mjs}'],
     rules: {
       'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],


### PR DESCRIPTION
## Summary
- allow ESLint to treat JavaScript files in src/main/webapp as browser code
- declare MockApi as a readonly global for those files to avoid undefined errors

## Testing
- npm run lint -- --max-warnings=0

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937ab1c2a3c8329b76819e10b486c94)